### PR TITLE
Adapt caenCliRootWF to new CAEN converter data format

### DIFF
--- a/user/caen-dt5742/module/exe/caenCliRootWF.cxx
+++ b/user/caen-dt5742/module/exe/caenCliRootWF.cxx
@@ -201,7 +201,7 @@ void CAENDT5742Events::initialize(const std::shared_ptr<const eudaq::Event> & bo
     // Extract the initial (hardcoded to 0) and the temporal step value of the waveforms
     // --- in SECONDS
     _t0[device_id] = 0.0;
-    _dt[device_id] = (_sampling_frequency_MHz*1e6)/_n_samples_per_waveform;
+    _dt[device_id] = 1.0 / (_sampling_frequency_MHz * 1.0e6);
 
     // Print-out the topology of the sensor and wire-bonding
     /*std::cout << " Defined DUTs in [" << _name[device_id] << "] digitizer: " << std::endl;
@@ -511,13 +511,12 @@ void ROOTCreator::fill_event_waveforms(CAENDT5742Events & caen,
         // in the configuration file (so extracted in the `initialize` method)
         for(const auto & chid: caen.get_channel_list(device_id, dutname_sensorid.first))
         {
-            if( caen.get_rows_and_columns_list(device_id,dutname_sensorid.second,chid).size() > 1 )
+            const auto row_col_list = caen.get_rows_and_columns_list(device_id, dutname_sensorid.second, chid);
+            for(size_t i = 0; i < row_col_list.size(); ++i)
             {
-                const std::string msg("Unable to deal with more than one pixel per channel... ");
-                throw std::runtime_error(msg);
+                _volt->push_back(dut_plane.GetWaveform(pixid));
+                ++pixid;
             }
-            _volt->push_back( dut_plane.GetWaveform(pixid) );
-            ++pixid;
         }
     }
     _wf_tree->Fill();


### PR DESCRIPTION
### Motivation
- The CAEN converter now represents waveform timing and pixel mappings differently, so the CLI that writes ROOT waveforms must use the same timing units and consume one waveform per mapped pixel. 

### Description
- Updated `user/caen-dt5742/module/exe/caenCliRootWF.cxx` to compute the waveform time step as `1.0 / (sampling_frequency_MHz * 1.0e6)` so `dt` is in seconds per sample. 
- Replaced the previous hard-failure when a channel maps to multiple pixels with logic that iterates over the channel's `(row,col)` list and pushes one waveform per mapped pixel while preserving the converter pixel ordering. 
- Adjusted waveform extraction bookkeeping to increment the plane pixel index (`pixid`) for each pushed waveform.

### Testing
- Ran `git diff --check` to validate patch formatting and whitespace, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e63f077c8328b3a9d9054d2e3450)